### PR TITLE
Fix typo in exportparts syntax example

### DIFF
--- a/explainers/css-shadow-parts-1.md
+++ b/explainers/css-shadow-parts-1.md
@@ -158,7 +158,7 @@ The `::part` forwarding syntax has options a-plenty.
   x-bar::part(some-input) { ... }
   ```
 
-- `exportparts="some-input foo-input"`:
+- `exportparts="some-input: foo-input"`:
   explicitly forward (some) of `x-foo`’s parts (i.e. some-input)
   but rename them.
   These selectors *would* match:


### PR DESCRIPTION
[According to the spec](https://drafts.csswg.org/css-shadow-parts/#parsing-mapping), when forwarding parts, the idents in the part mapping should be separated by a colon (`:`) not a space. Perhaps this was an accidental omission (I have not tested the code). 

The example in the spec [Example 2](https://drafts.csswg.org/css-shadow-parts/#example-d23fb781) is seemingly at odds with the explanation of the algorithm for parsing the parts mapping, also missing the colon.